### PR TITLE
Feature: Added forgot password page with email validation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import StatusDashboard from '@/components/StatusDashboard'
 import Home from '@/components/Home'
 import SignupForm from "@/components/SignupForm";
 import SigninForm from '@/components/SigninForm';
+import ForgotPassword from '@/components/ForgotPassword';
 
 function App() {
 	return (
@@ -13,6 +14,7 @@ function App() {
 				<Route path="/status" element={<StatusDashboard />} />
 				<Route path="/signup" element={<SignupForm />} />
 				<Route path="/signin" element={<SigninForm />} />
+				<Route path="/forgot-password" element={<ForgotPassword />} />
 				<Route path="*" element={<Navigate to="/" replace />} />
 			</Routes>
 		</Router>

--- a/frontend/src/components/ForgotPassword.tsx
+++ b/frontend/src/components/ForgotPassword.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ArrowLeft } from "lucide-react";
+
+export default function ForgotPassword() {
+	const [email, setEmail] = useState("");
+
+	// Handle form submission for password recovery
+	const handleSubmit = (e: React.FormEvent) => {
+		e.preventDefault();
+		console.log("Password recovery requested for email:", email);
+		// TODO: Implement password recovery API call
+		// This will send a 6-digit verification code to the user's email
+	};
+
+	// Validate email format
+	const isValidEmail = (email: string) => {
+		const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+		return emailRegex.test(email);
+	};
+
+	return (
+		<div className="flex flex-col items-center justify-center min-h-screen">
+			<div className="w-full max-w-lg p-8 flex flex-col items-center justify-center">
+				{/* Main header */}
+				<div className="text-center mb-4">
+					<h3 className="text-3xl font-medium">Forgot Password</h3>
+				</div>
+
+				{/* instructions */}
+				<div className="text-center mb-10">
+					<p className="text-base text-gray-600 leading-relaxed">
+						Enter the email you used to create your account so we can 
+						send you instructions on how to reset your password
+					</p>
+				</div>
+
+				<form className="space-y-8 w-full" onSubmit={handleSubmit}>
+					{/* Email text field with validation */}
+					<div className="space-y-3">
+						<label htmlFor="email" className="block text-base font-medium">
+							Email
+						</label>
+						<Input
+							id="email"
+							type="email"
+							className="w-full rounded-md h-12 text-base px-4 border border-black"
+							value={email}
+							onChange={(e) => setEmail(e.target.value)}
+							placeholder="Enter your email address"
+							required
+						/>
+					</div>
+
+					{/* Back to login page */}
+					<div className="flex justify-start">
+						<Link 
+							to="/signin" 
+							className="text-base font-medium text-primary hover:underline underline flex items-center gap-2"
+						>
+							<ArrowLeft size={18} />
+							Back To Login
+						</Link>
+					</div>
+
+					{/* Send Code button with validation */}
+					<Button
+						type="submit"
+						className="w-full rounded-full hover:bg-opacity-90 h-12 text-base"
+						disabled={!email || !isValidEmail(email)}
+					>
+						Send Code
+					</Button>
+				</form>
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/components/SigninForm.tsx
+++ b/frontend/src/components/SigninForm.tsx
@@ -79,8 +79,8 @@ export default function SigninForm() {
 										Remember me
 									</label>
                                 </div>
-                                {/* TODO: change url to actual forget password page */}
-								<Link to="#" className="text-sm font-medium">
+                                {/* Link to forgot password page */}
+								<Link to="/forgot-password" className="text-sm font-medium">
 									Forgot password?
 								</Link>
 							</div>


### PR DESCRIPTION
This pull request adds a "Forgot Password" feature. It allows users to request a password reset link via email. The main changes include updating routing to support the new page, and linking it from the sign-in form.

* Added a new `ForgotPassword` component (`frontend/src/components/ForgotPassword.tsx`) that displays a form for users to enter their email and request a password reset code. The component includes email validation and a link to return to the login page.
* Updated the sign-in form (`SigninForm.tsx`) to link to the new forgot password page instead of a placeholder.
* Imported the new `ForgotPassword` component in `App.tsx`.
* Added a route for `/forgot-password` in the main app router to display the new component.

Closes #144 

**Images:**

<img width="1920" height="1080" alt="Invalid Email" src="https://github.com/user-attachments/assets/fd742ef1-ff1a-4255-a5a4-a46369ab7eaf" />
<img width="1920" height="1080" alt="Valid Email" src="https://github.com/user-attachments/assets/2d0d18e4-db4f-41c7-a285-209ee8891c03" />
<img width="416" height="852" alt="Valid Email Mobile (Iphone XR)" src="https://github.com/user-attachments/assets/a7ff5a1f-560a-46f1-94d6-578eecefcc6c" />

